### PR TITLE
optimized function in input_ids.rs

### DIFF
--- a/src/input_ids.rs
+++ b/src/input_ids.rs
@@ -49,17 +49,15 @@ impl<const N: usize> InputIds<N> {
         assert_eq!(i, N, "Expected exactly {N} token_ids");
     }
 
-    pub fn apply_delay_pattern_mask(&self, pad_token_id: i64) -> Self {
-        // TODO: copying the whole array each time is not efficient.
-        let mut batches = self.batches.clone();
-        for i in 0..batches.len() {
-            for j in 0..batches[0].len() {
+    pub fn apply_delay_pattern_mask(&mut self, pad_token_id: i64) -> &mut Self{
+        for i in 0..self.batches.len() {
+            for j in 0..self.batches[0].len() {
                 if i % N >= j {
-                    batches[i][j] = pad_token_id;
+                    self.batches[i][j] = pad_token_id;
                 }
             }
         }
-        Self { batches }
+        self
     }
 
     pub fn last(&self) -> Tensor<i64> {


### PR DESCRIPTION
## Before:
<img width="694" alt="image" src="https://github.com/darshi1337/ChantGPT/assets/137528221/2b1e0566-f96a-45b2-9117-98b0e5baa27d">

## Changes:
changed the function's parameter in `input_ids.rs` to a mutable reference (`&mut self`) to prevent copying

## After:
<img width="726" alt="image" src="https://github.com/darshi1337/ChantGPT/assets/137528221/795336ab-0fae-4d27-97f0-96dc375670fc">
